### PR TITLE
Allow to use coma in numbers

### DIFF
--- a/addon/number.js
+++ b/addon/number.js
@@ -36,6 +36,10 @@ const {
  * @param {String} attribute
  */
 export default function validateNumber(value, options) {
+  if (typeof value === 'string') {
+    value = value.replace(/,/g, '.');
+  }
+
   let numValue = Number(value);
   let optionKeys = Object.keys(options);
   let { allowBlank, allowString, integer } = getProperties(options, ['allowBlank', 'allowString', 'integer']);

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -23,7 +23,7 @@ test('no options', function(assert) {
 });
 
 test('allow string', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   options = {
     allowString: true
@@ -33,6 +33,9 @@ test('allow string', function(assert) {
   assert.equal(processResult(result), true);
 
   result = validate('22.22', cloneOptions(options));
+  assert.equal(processResult(result), true);
+
+  result = validate('22,22', cloneOptions(options));
   assert.equal(processResult(result), true);
 
   result = validate('test', cloneOptions(options));


### PR DESCRIPTION
In french, and in some other languages, coma are used instead of dos to separate numbers.

Not sure about the implementation but I didn't found an other way.