### PR TITLE
[BUGFIX] Use String.match instead of RegExp.test to support g flag

### DIFF
--- a/addon/format.js
+++ b/addon/format.js
@@ -68,7 +68,7 @@ export default function validateFormat(value, options, model, attribute) {
     set(options, 'regex', regex);
   }
 
-  if (regex && !regex.test(value)) {
+  if ((isNone(value) || typeof value !== 'string') || (regex && isEmpty(value.match(regex)))) {
     return validationError(type || 'invalid', value, options);
   }
 

--- a/addon/format.js
+++ b/addon/format.js
@@ -13,6 +13,7 @@ const {
   isEmpty,
   assert,
   deprecate,
+  canInvoke,
   getProperties
 } = Ember;
 
@@ -68,7 +69,7 @@ export default function validateFormat(value, options, model, attribute) {
     set(options, 'regex', regex);
   }
 
-  if ((isNone(value) || typeof value !== 'string') || (regex && isEmpty(value.match(regex)))) {
+  if (!canInvoke(value, 'match') || (regex && isEmpty(value.match(regex)))) {
     return validationError(type || 'invalid', value, options);
   }
 

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -170,7 +170,7 @@ test('url', function(assert) {
 });
 
 test('custom', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   options = {
     regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/
@@ -178,9 +178,31 @@ test('custom', function(assert) {
 
   options = cloneOptions(options);
 
+  result = validate(null, options);
+  assert.equal(processResult(result), 'This field is invalid');
+
   result = validate('password', options);
   assert.equal(processResult(result), 'This field is invalid');
 
   result = validate('Pass123', options);
   assert.equal(processResult(result), true);
+});
+
+test('custom with g flag', function(assert) {
+  assert.expect(3);
+
+  options = {
+    regex: /foo/g
+  };
+
+  options = cloneOptions(options);
+
+  result = validate('foo', options);
+  assert.equal(processResult(result), true);
+
+  result = validate('foo', options);
+  assert.equal(processResult(result), true);
+
+  result = validate('bar', options);
+  assert.equal(processResult(result), 'This field is invalid');
 });

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -60,6 +60,9 @@ test('email', function(assert) {
     'EMAIL@DOMAIN.COM'
   ];
   let invalidAddresses = [
+    null,
+    undefined,
+    404,
     'plainaddress',
     '#@%^%#$@#$@#.com',
     '@domain.com',


### PR DESCRIPTION
Resolves offirgolan/ember-cp-validations#423.

@stefanpenner what do you think about this change? Are there any edge cases that might break this or will this cause any serious performance issues? 

From my research, it looks like `RegExp.test` is a more optimal solution but it doesnt seem TOO significant. 