### PR TITLE
Add "not" validator in Number validators

### DIFF
--- a/addon/messages.js
+++ b/addon/messages.js
@@ -82,6 +82,7 @@ export default {
   email: '{description} must be a valid email address',
   empty: '{description} can\'t be empty',
   equalTo: '{description} must be equal to {is}',
+  notEqualTo: '{description} mustn\'t be equal to {not}',
   even: '{description} must be even',
   exclusion: '{description} is reserved',
   greaterThan: '{description} must be greater than {gt}',

--- a/addon/number.js
+++ b/addon/number.js
@@ -28,6 +28,7 @@ const {
  * @param {Boolean} options.odd Number must be odd
  * @param {Boolean} options.even Number must be even
  * @param {Number} options.is Number must be equal to this value
+ * @param {Number} options.not Number must not be equal to this value
  * @param {Number} options.lt Number must be less than this value
  * @param {Number} options.lte Number must be less than or equal to this value
  * @param {Number} options.gt Number must be greater than this value
@@ -74,6 +75,8 @@ function _validateType(type, options, value) {
 
   if (type === 'is' && actual !== expected) {
     return validationError('equalTo', value, options);
+  } else if (type === 'not' && actual === expected) {
+    return validationError('notEqualTo', value, options);
   } else if (type === 'lt' && actual >= expected) {
     return validationError('lessThan', value, options);
   } else if (type === 'lte' && actual > expected) {

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -81,6 +81,20 @@ test('is', function(assert) {
   assert.equal(processResult(result), true);
 });
 
+test('not', function(assert) {
+  assert.expect(2);
+
+  options = {
+    not: 22
+  };
+
+  result = validate(22, cloneOptions(options));
+  assert.equal(processResult(result), 'This field mustn\'t be equal to 22');
+
+  result = validate(1, cloneOptions(options));
+  assert.equal(processResult(result), true);
+});
+
 test('lt', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
I need to be sure that the user choose a number differents to another one.

I can make a second PR on ember-cp-validations to update the documentation if you want :)