### PR TITLE
Add "is" and not" validators in Date validators

### DIFF
--- a/addon/date.js
+++ b/addon/date.js
@@ -31,6 +31,8 @@ const {
  * @param {Any} value
  * @param {Object} options
  * @param {Boolean} options.allowBlank If true, skips validation if the value is empty
+ * @param {String} options.is The specified date must be this date
+ * @param {String} options.not The specified date mustn't be this date
  * @param {String} options.before The specified date must be before this date
  * @param {String} options.onOrBefore The specified date must be on or before this date
  * @param {String} options.after The specified date must be after this date
@@ -45,7 +47,7 @@ const {
 export default function validateDate(value, options) {
   let errorFormat = getWithDefault(options, 'errorFormat', 'MMM Do, YYYY');
   let { format, precision, allowBlank } = getProperties(options, ['format', 'precision', 'allowBlank']);
-  let { before, onOrBefore, after, onOrAfter } = getProperties(options, ['before', 'onOrBefore', 'after', 'onOrAfter']);
+  let { is, not, before, onOrBefore, after, onOrAfter } = getProperties(options, ['before', 'onOrBefore', 'after', 'onOrAfter']);
   let date;
 
   if (allowBlank && isEmpty(value)) {
@@ -61,6 +63,22 @@ export default function validateDate(value, options) {
     date = parseDate(value);
     if (!date.isValid()) {
       return validationError('date', value, options);
+    }
+  }
+
+  if (is) {
+    is = _parseDate(is, format);
+    if (!date.isSame(is, precision)) {
+      set(options, 'is', is.format(errorFormat));
+      return validationError('equalTo', value, options);
+    }
+  }
+
+  if (not) {
+    not = _parseDate(not, format);
+    if (date.isSame(not, precision)) {
+      set(options, 'not', not.format(errorFormat));
+      return validationError('notEqualTo', value, options);
     }
   }
 

--- a/addon/messages.js
+++ b/addon/messages.js
@@ -82,6 +82,7 @@ export default {
   email: '{description} must be a valid email address',
   empty: '{description} can\'t be empty',
   equalTo: '{description} must be equal to {is}',
+  notEqualTo: '{description} mustn\'t be equal to {not}',
   even: '{description} must be even',
   exclusion: '{description} is reserved',
   greaterThan: '{description} must be greater than {gt}',

--- a/tests/unit/validators/date-test.js
+++ b/tests/unit/validators/date-test.js
@@ -74,6 +74,34 @@ test('error date format', function(assert) {
   assert.equal(processResult(result), 'This field must be before 1/1/2015');
 });
 
+test('is', function(assert) {
+  assert.expect(2);
+
+  options = {
+    is: '1/1/2015'
+  };
+
+  result = validate('1/1/2016', cloneOptions(options));
+  assert.equal(processResult(result), 'This field must be Jan 1st, 2015');
+
+  result = validate('1/1/2015', cloneOptions(options));
+  assert.equal(processResult(result), true);
+});
+
+test('not', function(assert) {
+  assert.expect(2);
+
+  options = {
+    not: '1/1/2015'
+  };
+
+  result = validate('1/1/2015', cloneOptions(options));
+  assert.equal(processResult(result), 'This field mustn \'t be Jan 1st, 2015');
+
+  result = validate('1/1/2016', cloneOptions(options));
+  assert.equal(processResult(result), true);
+});
+
 test('before', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
I need to be sure that the user choose a date differents/equals to another one.
(yes I know it can sounds crazy but I have some use cases)

I can make a second PR on ember-cp-validations to update the documentation if you want :)