### PR TITLE
[FEATURE] Support Ember Changeset Validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ function (value, options, model, attribute) {}
 
   `true` will be returned if the validation passed
 
-- **String**
-
-  Validation failed with the given error message
-
 - **Object**
 
   Validation failed and a message should be built with the given attributes
@@ -95,3 +91,7 @@ function (value, options, model, attribute) {}
   - context (**Object**):
 
     The error message context
+
+  - message (**String**):
+
+    The error message. If this is specified, use this string as the error message instead of building one.

--- a/addon/confirmation.js
+++ b/addon/confirmation.js
@@ -10,6 +10,7 @@ const {
   get,
   assert,
   isEqual,
+  isEmpty,
   isPresent
 } = Ember;
 
@@ -23,13 +24,19 @@ const {
  * @param {Any} value
  * @param {Object} options
  * @param {String} options.on The attribute to confirm against
+ * @param {String} options.allowBlank If true, skips validation if the value is empty
  * @param {Object} model
  * @param {String} attribute
  */
 export default function validateConfirmation(value, options, model, attribute) {
   let on = get(options, 'on');
+  let allowBlank = get(options, 'allowBlank');
 
   assert(`[validator:confirmation] [${attribute}] option 'on' is required`, isPresent(on));
+
+  if (allowBlank && isEmpty(value)) {
+    return true;
+  }
 
   if (!isEqual(value, get(model, on))) {
     return validationError('confirmation', value, options);

--- a/addon/ds-error.js
+++ b/addon/ds-error.js
@@ -5,6 +5,7 @@
 
 import Ember from 'ember';
 import requireModule from 'ember-require-module';
+import validationError from 'ember-validators/utils/validation-error';
 
 const DS = requireModule('ember-data');
 
@@ -35,7 +36,7 @@ export default function validateDsError(value, options, model, attribute) {
   let errors = get(model, path);
 
   if (!isNone(errors) && errors instanceof DS.Errors && errors.has(key)) {
-    return get(errors.errorsFor(key), 'lastObject.message');
+    return validationError('ds', null, options, get(errors.errorsFor(key), 'lastObject.message'));
   }
 
   return true;

--- a/addon/length.js
+++ b/addon/length.js
@@ -44,15 +44,21 @@ export default function validateLength(value, options, model, attribute) {
     return true;
   }
 
-  if (!isNone(is) && is !== get(value, 'length')) {
+  let length = get(value, 'length');
+
+  if (!isNone(is) && is !== length) {
     return validationError('wrongLength', value, options);
   }
 
-  if (!isNone(min) && min > get(value, 'length')) {
+  if (!isNone(min) && !isNone(max) && (length < min || length > max)) {
+    return validationError('between', value, options);
+  }
+
+  if (!isNone(min) && min > length) {
     return validationError('tooShort', value, options);
   }
 
-  if (!isNone(max) && max < get(value, 'length')) {
+  if (!isNone(max) && max < length) {
     return validationError('tooLong', value, options);
   }
 

--- a/addon/length.js
+++ b/addon/length.js
@@ -25,6 +25,7 @@ const {
  * @param {Object} options
  * @param {Boolean} options.allowNone If true, skips validation if the value is null or undefined. __Default: true__
  * @param {Boolean} options.allowBlank If true, skips validation if the value is empty
+ * @param {Boolean} options.useBetweenMessage If true, uses the between error message when `max` and `min` are both set
  * @param {Number} options.is The exact length the value can be
  * @param {Number} options.min The minimum length the value can be
  * @param {Number} options.max The maximum length the value can be
@@ -32,7 +33,7 @@ const {
  * @param {String} attribute
  */
 export default function validateLength(value, options, model, attribute) {
-  let { allowNone, allowBlank, is, min, max } = getProperties(options, [ 'allowNone', 'allowBlank', 'is', 'min', 'max' ]);
+  let { allowNone = true, allowBlank, useBetweenMessage, is, min, max } = getProperties(options, [ 'allowNone', 'allowBlank', 'useBetweenMessage', 'is', 'min', 'max' ]);
 
   assert(`[validator:length] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
 
@@ -50,7 +51,7 @@ export default function validateLength(value, options, model, attribute) {
     return validationError('wrongLength', value, options);
   }
 
-  if (!isNone(min) && !isNone(max) && (length < min || length > max)) {
+  if (useBetweenMessage && !isNone(min) && !isNone(max) && (length < min || length > max)) {
     return validationError('between', value, options);
   }
 

--- a/addon/messages.js
+++ b/addon/messages.js
@@ -98,10 +98,12 @@ export default {
   otherThan: '{description} must be other than {value}',
   phone: '{description} must be a valid phone number',
   positive: '{description} must be positive',
+  multipleOf: '{description} must be a multiple of {multipleOf}',
   present: '{description} must be blank',
   singular: '{description} can\'t be a collection',
   tooLong: '{description} is too long (maximum is {max} characters)',
   tooShort: '{description} is too short (minimum is {min} characters)',
+  between: '{description} must be between {min} and {max} characters',
   url: '{description} must be a valid url',
   wrongDateFormat: '{description} must be in the format of {format}',
   wrongLength: '{description} is the wrong length (should be {is} characters)'

--- a/addon/number.js
+++ b/addon/number.js
@@ -32,6 +32,7 @@ const {
  * @param {Number} options.lte Number must be less than or equal to this value
  * @param {Number} options.gt Number must be greater than this value
  * @param {Number} options.gte Number must be greater than or equal to this value
+ * @param {Number} options.multipleOf Number must be a multiple of this value
  * @param {Object} model
  * @param {String} attribute
  */
@@ -88,6 +89,8 @@ function _validateType(type, options, value) {
     return validationError('odd', value, options);
   } else if (type === 'even' && actual % 2 !== 0) {
     return validationError('even', value, options);
+  } else if (type === 'multipleOf' && !isInteger(actual / expected)) {
+    return validationError('multipleOf', value, options);
   }
 
   return true;

--- a/addon/number.js
+++ b/addon/number.js
@@ -8,6 +8,7 @@ import validationError from 'ember-validators/utils/validation-error';
 
 const {
   get,
+  isNone,
   isEmpty,
   getProperties
 } = Ember;
@@ -22,6 +23,7 @@ const {
  * @param {Any} value
  * @param {Object} options
  * @param {Boolean} options.allowBlank If true, skips validation if the value is empty
+ * @param {Boolean} options.allowNone If true, skips validation if the value is null or undefined. __Default: true__
  * @param {Boolean} options.allowString If true, validator will accept string representation of a number
  * @param {Boolean} options.integer Number must be an integer
  * @param {Boolean} options.positive Number must be greater than 0
@@ -39,7 +41,11 @@ const {
 export default function validateNumber(value, options) {
   let numValue = Number(value);
   let optionKeys = Object.keys(options);
-  let { allowBlank, allowString, integer } = getProperties(options, ['allowBlank', 'allowString', 'integer']);
+  let { allowBlank, allowNone = true, allowString, integer } = getProperties(options, ['allowBlank', 'allowNone', 'allowString', 'integer']);
+
+  if (!allowNone && isNone(value)) {
+    return validationError('notANumber', value, options);
+  }
 
   if (allowBlank && isEmpty(value)) {
     return true;

--- a/addon/utils/validation-error.js
+++ b/addon/utils/validation-error.js
@@ -3,6 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
-export default function validationError(type, value, context) {
-  return { type, value, context };
+export default function validationError(type, value, context, message) {
+  return { type, value, context, message };
 }

--- a/tests/helpers/process-result.js
+++ b/tests/helpers/process-result.js
@@ -7,7 +7,12 @@ const {
 
 export default function processResult(result) {
   if (result && typeof result === 'object') {
-    let { type, context } = result;
+    let { type, context, message } = result;
+
+    if (message) {
+      return message;
+    }
+
     set(context, 'description', Messages.getDescriptionFor(undefined, context));
     return Messages.getMessageFor(type, context);
   }

--- a/tests/unit/validators/confirmation-test.js
+++ b/tests/unit/validators/confirmation-test.js
@@ -29,3 +29,12 @@ test('attribute', function(assert) {
   result = validate('foo@yahoo.com', cloneOptions(options), model);
   assert.equal(processResult(result), true);
 });
+
+test('allowBlank', function(assert) {
+  assert.expect(1);
+
+  options = { on: 'email', allowBlank: true };
+
+  result = validate('', cloneOptions(options), model);
+  assert.equal(processResult(result), true);
+});

--- a/tests/unit/validators/format-test.js
+++ b/tests/unit/validators/format-test.js
@@ -4,7 +4,7 @@
  */
 
 import { module, test } from 'qunit';
-import { default as validate, regularExpressions } from 'ember-validators/format';
+import validate from 'ember-validators/format';
 import processResult from '../../helpers/process-result';
 import cloneOptions from '../../helpers/clone-options';
 
@@ -33,8 +33,7 @@ test('allow blank', function(assert) {
 
   options = {
     allowBlank: true,
-    type: 'email',
-    regex: regularExpressions.email
+    type: 'email'
   };
   options = cloneOptions(options);
 
@@ -90,8 +89,7 @@ test('email', function(assert) {
   assert.expect(validAddresses.length + invalidAddresses.length);
 
   options = {
-    type: 'email',
-    regex: regularExpressions.email
+    type: 'email'
   };
 
   testEmailAddresses(assert, options, validAddresses, invalidAddresses);
@@ -107,7 +105,6 @@ test('email + allowNonTld', function(assert) {
 
   options = {
     type: 'email',
-    regex: regularExpressions.email,
     allowNonTld: true
   };
 
@@ -131,7 +128,6 @@ test('email + minTldLength', function(assert) {
 
   options = {
     type: 'email',
-    regex: regularExpressions.email,
     minTldLength: 2
   };
 
@@ -142,8 +138,7 @@ test('phone', function(assert) {
   assert.expect(2);
 
   options = {
-    type: 'phone',
-    regex: regularExpressions.phone
+    type: 'phone'
   };
 
   options = cloneOptions(options);
@@ -159,8 +154,7 @@ test('url', function(assert) {
   assert.expect(2);
 
   options = {
-    type: 'url',
-    regex: regularExpressions.url
+    type: 'url'
   };
 
   options = cloneOptions(options);
@@ -169,6 +163,40 @@ test('url', function(assert) {
   assert.equal(processResult(result), 'This field must be a valid url');
 
   result = validate('http://www.yahoo.com', options);
+  assert.equal(processResult(result), true);
+});
+
+test('inverse - with type', function(assert) {
+  assert.expect(2);
+
+  options = {
+    type: 'email',
+    inverse: true
+  };
+
+  options = cloneOptions(options);
+
+  result = validate('email@domain.com', options);
+  assert.equal(processResult(result), 'This field must be a valid email address');
+
+  result = validate('foobar123', options);
+  assert.equal(processResult(result), true);
+});
+
+test('inverse - custom', function(assert) {
+  assert.expect(2);
+
+  options = {
+    inverse: true,
+    regex: /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{4,8}$/
+  };
+
+  options = cloneOptions(options);
+
+  result = validate('Pass123', options);
+  assert.equal(processResult(result), 'This field is invalid');
+
+  result = validate('foobar', options);
   assert.equal(processResult(result), true);
 });
 

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -94,6 +94,24 @@ test('max', function(assert) {
   assert.equal(processResult(result), true);
 });
 
+test('between', function(assert) {
+  assert.expect(3);
+
+  options = {
+    min: 1,
+    max: 5
+  };
+
+  result = validate('', cloneOptions(options));
+  assert.equal(processResult(result), 'This field must be between 1 and 5 characters');
+
+  result = validate('123456', cloneOptions(options));
+  assert.equal(processResult(result), 'This field must be between 1 and 5 characters');
+
+  result = validate('1234', cloneOptions(options));
+  assert.equal(processResult(result), true);
+});
+
 test('array', function(assert) {
   assert.expect(2);
 

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -99,7 +99,8 @@ test('between', function(assert) {
 
   options = {
     min: 1,
-    max: 5
+    max: 5,
+    useBetweenMessage: true
   };
 
   result = validate('', cloneOptions(options));

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -132,6 +132,23 @@ test('gt', function(assert) {
   assert.equal(processResult(result), true);
 });
 
+test('multipleOf', function(assert) {
+  assert.expect(3);
+
+  options = {
+    multipleOf: 2
+  };
+
+  result = validate(5, cloneOptions(options));
+  assert.equal(processResult(result), 'This field must be a multiple of 2');
+
+  result = validate(17, cloneOptions(options));
+  assert.equal(processResult(result), 'This field must be a multiple of 2');
+
+  result = validate(22, cloneOptions(options));
+  assert.equal(processResult(result), true);
+});
+
 test('gte', function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
## API Changes

- Validators will now always return either `true` or a `ValidationError`. If a specific message is returned, instead of returning a string, it will now be under the `message` property of the error object.

## Validator Changes

- Confirmation
  - allowBlank
- Format
  - inverse
  - Remove deprecated emailOptionalTld
  - Auto include regex from type
- Length
  - Default allowNone to true
  - useBetweenMessage (If min and max are set, use the `between` error message type
- Number
  - allowNone (defaulted to true)
  - multipleOf
