### PR TITLE
[BUGFIX] Remove assert in length validator

### DIFF
--- a/addon/length.js
+++ b/addon/length.js
@@ -8,7 +8,6 @@ import validationError from 'ember-validators/utils/validation-error';
 
 const {
   get,
-  assert,
   isNone,
   isEmpty,
   getProperties
@@ -32,10 +31,8 @@ const {
  * @param {Object} model
  * @param {String} attribute
  */
-export default function validateLength(value, options, model, attribute) {
+export default function validateLength(value, options) {
   let { allowNone = true, allowBlank, useBetweenMessage, is, min, max } = getProperties(options, [ 'allowNone', 'allowBlank', 'useBetweenMessage', 'is', 'min', 'max' ]);
-
-  assert(`[validator:length] [${attribute}] no options were passed in`, !isEmpty(Object.keys(options)));
 
   if (isNone(value)) {
     return allowNone ? true : validationError('invalid', value, options);

--- a/tests/unit/validators/length-test.js
+++ b/tests/unit/validators/length-test.js
@@ -15,11 +15,8 @@ module('Unit | Validator | length');
 test('no options', function(assert) {
   assert.expect(1);
 
-  try {
-    result = validate(undefined, {});
-  } catch (e) {
-    assert.ok(true);
-  }
+  result = validate(undefined, {});
+  assert.ok(true);
 });
 
 test('allow blank', function(assert) {


### PR DESCRIPTION
This assert no longer makes sense since `allowNone` is defaulted to true. 