### PR TITLE
Use consistent semver of ember-require-module

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-require-module": "0.1.1"
+    "ember-require-module": "^0.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Currently ember-cp-validations requires `^0.1.1` which resolves to `0.1.2`, while ember-validators requires `0.1.1`. This causes two versions of ember-require-module being installed.

```sh
$ ember dependency-lint
ember-require-module
Allowed: (any single version)
Found: 0.1.2, 0.1.1
my-app
└─┬ ember-cp-validations
  ├── ember-require-module@0.1.2
  └─┬ ember-validators
    └── ember-require-module@0.1.1
```