### PR TITLE
Allow for partial application of the message context

### DIFF
--- a/addon/messages.js
+++ b/addon/messages.js
@@ -54,6 +54,31 @@ export default {
   },
 
   /**
+   * Finds the placeholders and replace them with values
+   * from context depending on the availability requirements.
+   * @method formatMessage
+   * @param  {String} message
+   * @param  {Object} context
+   * @param  {Boolean} applyAll
+   * @return {String}
+   * @private
+   */
+  _formatMessage(message, context = {}, applyAll = true) {
+    let m = message;
+
+    if (isNone(m) || typeof m !== 'string') {
+      m = get(this, 'invalid');
+    }
+    return m.replace(get(this, '_regex'), (s, attr) => {
+      let hasActualValue = typeof context === 'object' && context.hasOwnProperty(attr);
+      if (hasActualValue || applyAll) {
+        return get(context, attr);
+      }
+      return s;
+    });
+  },
+
+  /**
    * Regex replace all placeholders with their given context
    * @method formatMessage
    * @param  {String} message
@@ -61,12 +86,20 @@ export default {
    * @return {String}
    */
   formatMessage(message, context = {}) {
-    let m = message;
+    return this._formatMessage(message, context, true);
+  },
 
-    if (isNone(m) || typeof m !== 'string') {
-      m = get(this, 'invalid');
-    }
-    return m.replace(get(this, '_regex'), (s, attr) => get(context, attr));
+  /**
+   * Regex replace placeholders with their given context
+   * for the keys provided by the the context. Leaves the
+   * unavailable keys untouched.
+   * @method formatMessage
+   * @param  {String} message
+   * @param  {Object} context
+   * @return {String}
+   */
+  formatPartialMessage(message, context = {}) {
+    return this._formatMessage(message, context, false);
   },
 
   /**

--- a/tests/unit/validators/messages-test.js
+++ b/tests/unit/validators/messages-test.js
@@ -24,6 +24,16 @@ test('formatMessage', function(assert) {
   assert.equal(messages.formatMessage('{foo} {foo} {bar} {baz}', { foo: 'a', bar: 1, baz: 'abc' }), 'a a 1 abc');
 });
 
+test('formatPartialMessage', function(assert) {
+  assert.expect(3);
+  let context = {
+    description: 'This field'
+  };
+  assert.equal(messages.formatPartialMessage(undefined, context), 'This field is invalid');
+  assert.equal(messages.formatPartialMessage('{foo} is undefined'), '{foo} is undefined');
+  assert.equal(messages.formatPartialMessage('{foo} {foo} {bar} {baz}', { foo: 'a', bar: 1 }), 'a a 1 {baz}');
+});
+
 test('getMessageFor', function(assert) {
   assert.expect(2);
   let context = {


### PR DESCRIPTION
This PR allows, with a backward compatible modification, to let the developers partially apply a context to a message.

This is very useful for instance when extending the messages provided by `ember-validations` to reuse `messageFor` to do the extension/replacement instead of doing a `.replace(...)` manually, which might break eventually...

### Down to earth example:
* we were working with `wrongDateFormat` ("{description} must be in the format of {format}")
* The `format` used was `L` (using the moment terminology)
* We wanted the localised version of `L` ("MM/DD/YYYY" in en_US and "JJ/MM/AAAA" in fr_FR) in the message
* We had to write this PR to allow for:
```
return this.formatPartialMessage(pattern, { format: localisedString});
// return value is "{description} must be in the format of JJ/MM/AAAA"
```

What do you think?