### PR TITLE
number: fix behavior of allowNone

### DIFF
--- a/addon/number.js
+++ b/addon/number.js
@@ -32,15 +32,19 @@ export default function validateNumber(value, options) {
   let optionKeys = Object.keys(options);
   let { allowBlank, allowNone = true, allowString, integer } = getProperties(options, ['allowBlank', 'allowNone', 'allowString', 'integer']);
 
-  if (!allowNone && isNone(value)) {
-    return validationError('notANumber', value, options);
+  if (allowNone && isNone(value)) {
+    return true;
   }
 
   if (allowBlank && isEmpty(value)) {
     return true;
   }
 
-  if (typeof value === 'string' && (isEmpty(value) || !allowString)) {
+  if (isEmpty(value)) {
+    return validationError('notANumber', value, options);
+  }
+
+  if (typeof value === 'string' && !allowString) {
     return validationError('notANumber', value, options);
   }
 

--- a/tests/unit/validators/number-test.js
+++ b/tests/unit/validators/number-test.js
@@ -8,9 +8,12 @@ let options, result;
 module('Unit | Validator | number');
 
 test('no options', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   result = validate(undefined, {});
+  assert.equal(processResult(result), true);
+
+  result = validate("", {});
   assert.equal(processResult(result), 'This field must be a number');
 
   result = validate(22, cloneOptions(options));
@@ -239,4 +242,26 @@ test('allowBlank', function(assert) {
 
   result = validate('', cloneOptions(options));
   assert.equal(processResult(result), true);
+});
+
+test('allowNone', function(assert) {
+  assert.expect(4);
+
+  options = {
+    allowNone: true
+  };
+
+  result = validate(null, cloneOptions(options));
+  assert.equal(processResult(result), true);
+
+  result = validate(undefined, cloneOptions(options));
+  assert.equal(processResult(result), true);
+
+  options.allowNone = false;
+
+  result = validate(null, cloneOptions(options));
+  assert.equal(processResult(result), "This field must be a number");
+
+  result = validate(undefined, cloneOptions(options));
+  assert.equal(processResult(result), "This field must be a number");
 });


### PR DESCRIPTION
For the number validator, the docs said that when `allowNone` was true, validation would be skipped if the value was `null` or `undefined`. What was actually happening is that validation would not be skipped at all in those cases.

Instead, only if `allowNone` was false, the validation would fail if the value was `null`/`undefined`.

The smallest possible fix here included also removing the default value on `allowNone`. This turns it into a purely opt-in option. However, it seems likely this would cause less breakage than the alternative (simply fixing the behavior to match the documentation).

If you would prefer that I leave the default & documentation untouched and instead just make the behavior actually match the docs, let me know and I'll be happy to make that change.

Cheers :v: