### PR TITLE
number: docfix for positive option

### DIFF
--- a/addon/number.js
+++ b/addon/number.js
@@ -15,7 +15,7 @@ import validationError from 'ember-validators/utils/validation-error';
  * @param {Boolean} options.allowNone If true, skips validation if the value is null or undefined. __Default: true__
  * @param {Boolean} options.allowString If true, validator will accept string representation of a number
  * @param {Boolean} options.integer Number must be an integer
- * @param {Boolean} options.positive Number must be greater than 0
+ * @param {Boolean} options.positive Number must be greater than or equal to 0
  * @param {Boolean} options.odd Number must be odd
  * @param {Boolean} options.even Number must be even
  * @param {Number} options.is Number must be equal to this value


### PR DESCRIPTION
The number validator with a `positive` option only validates that the number is not less than 0. This PR changes the docs to reflect that 0 is allowed.

This simple doc fix made more sense to me than changing the underlying behavior to match the docs, especially since [there is a test](https://github.com/offirgolan/ember-validators/blob/db8511ff64aa862cf4837014946b1916c9cff765/tests/unit/validators/number-test.js#L177-L178) explicitly verifying this behavior.