### PR TITLE
Bump ember-require-module dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.9.2",
-    "ember-require-module": "^0.2.0"
+    "ember-require-module": "^0.3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2990,9 +2990,10 @@ ember-qunit@^3.3.0:
     ember-cli-test-loader "^2.2.0"
     qunit "^2.5.0"
 
-ember-require-module@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.2.0.tgz#eafe436737ead4762220a9166b78364abf754274"
+ember-require-module@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-require-module/-/ember-require-module-0.3.0.tgz#65aff7908b5b846467e4526594d33cfe0c23456b"
+  integrity sha512-rYN4YoWbR9VlJISSmx0ZcYZOgMcXZLGR7kdvp3zDerjIvYmHm/3p+K56fEAYmJILA6W4F+cBe41Tq2HuQAZizA==
   dependencies:
     ember-cli-babel "^6.9.2"
 


### PR DESCRIPTION
This is needed to avoid conflicts with latest ember-cp-validations because ember-cp-validations@^4 depends on "ember-require-module": "^0.3.0"

See issue https://github.com/offirgolan/ember-cp-validations/issues/616

This change should be breaking since it will break compatibility with ember-cp-validations@^3, so, once it is merged, a new major version of ember-validators should be released.