### PR TITLE
Fix moment undefined bug when using embroider

### DIFF
--- a/addon/date.js
+++ b/addon/date.js
@@ -3,7 +3,7 @@ import { set, getProperties, getWithDefault } from '@ember/object';
 import validationError from 'ember-validators/utils/validation-error';
 import requireModule from 'ember-require-module';
 
-const moment = requireModule('moment');
+const moment = requireModule('moment') || requireModule('ember-cli-moment-shim');
 
 /**
  * @class Date


### PR DESCRIPTION
When building an Ember app with [embroider](https://github.com/embroider-build/embroider) and [ember-cli-moment-shim](https://github.com/jasonmit/ember-cli-moment-shim), the moment package will be renamed to ember-cli-moment-shim which causes the requireModule call to return undefined. 