### PR TITLE
Bump node version to fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "10"
 
 sudo: false
-dist: trusty
+dist: xenial
 
 addons:
   chrome: stable
@@ -23,8 +23,7 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,18 +2,10 @@ module.exports = {
   useYarn: true,
   scenarios: [
     {
-      name: 'ember-lts-2.12',
+      name: 'ember-lts-2.18',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
-        }
-      }
-    },
-    {
-      name: 'ember-lts-2.16',
-      npm: {
-        devDependencies: {
-          'ember-source': '~2.16.0'
+          'ember-source': '~2.18.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "yuidoc-ember-theme": "1.3.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "10.* || >= 12"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
As pointed out by @andreyfel in #67 node v4 is breaking CI builds.

Node versions taken from the current ember-cli blueprints.

If you're interested @offirgolan I can make a follow-up PR based off this with all packages updated to latest major version. Main advantage for addon consumers being that it depends on `ember-cli-babel` v7.