### PR TITLE
Add README example for building error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ validate('presence', 'foo', { presence: true });
 validate('length', 'foo', { min: 1 });
 ```
 
+### Messages
+When validation fails, you can build the error message manually.
+
+```js
+import messages from 'ember-validators/messages';
+import validateLength from 'ember-validators/length';
+
+const options = { min: 5 };
+const result = validateLength('foo', options);
+
+const errorMessage = messages.getMessageFor(result.type, { ...options, description: 'Page title' });
+
+alert(errorMessage); // "Page title is too short (minimum is 5 characters)"
+```
+
 ## Validator Method Signature
 
 Each validator has the following signature:


### PR DESCRIPTION
At the moment the failed validation result message is always `undefined`. Instead of creating custom error messages, devs can have the choice to use the built-in ones.